### PR TITLE
Add alternative "practice" timer

### DIFF
--- a/Source/Actors/Player.cs
+++ b/Source/Actors/Player.cs
@@ -170,6 +170,10 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 
 	private bool InBubble
 		=> stateMachine.State == States.Bubble;
+	
+	public bool InPausePracticeTimerState 
+		=> stateMachine.State == States.StrawbGet
+		|| stateMachine.State == States.Cassette;
 
 	public bool IsStrawberryCounterVisible
 		=> stateMachine.State == States.StrawbGet;
@@ -258,6 +262,8 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 		GetCameraTarget(out var orig, out var target, out _);
 		World.Camera.LookAt = target;
 		World.Camera.Position = orig;
+		
+		Save.CurrentRecord.ResetPracticeTimer();
 	}
 
 	public override void Update()

--- a/Source/Save.cs
+++ b/Source/Save.cs
@@ -20,6 +20,7 @@ public class Save
 		public Dictionary<string, int> Flags { get; set; } = []; 
 		public int Deaths { get; set; } = 0;
 		public TimeSpan Time { get; set; } = new();
+		public TimeSpan TimePractice { get; set; } = new();
 
 		public int GetFlag(string name, int defaultValue = 0) 
 			=> Flags.TryGetValue(name, out int value) ? value : defaultValue;
@@ -29,6 +30,9 @@ public class Save
 
 		public int IncFlag(string name) 
 			=> Flags[name] = GetFlag(name) + 1;
+
+		public void ResetPracticeTimer()
+			=> TimePractice = new TimeSpan();
 	}
 
 	public static Save Instance = new();
@@ -57,6 +61,15 @@ public class Save
 	/// If the Speedrun Timer should be visible while playing
 	/// </summary>
 	public bool SpeedrunTimer { get; set; } = false;
+
+	/// <summary>
+	/// If the Speeedrun Timer should display in "practice" mode rather than show the total playtime
+	/// When practice mode is enabled:
+	///  - Increment the timer while the player has control
+	///  - Reset the timer on respawn and after entering a cassette room
+	///  - Pause the timer when collecting a strawberry and when entering a cassette room
+	/// </summary>
+	public bool SpeedrunTimerPracticeMode { get; set; } = false;
 
 	/// <summary>
 	/// 0-10 Music volume level
@@ -126,6 +139,16 @@ public class Save
 	public void ToggleTimer()
 	{
 		SpeedrunTimer = !SpeedrunTimer;
+	}
+	
+	public void TogglePracticeTimer()
+	{
+		SpeedrunTimerPracticeMode = !SpeedrunTimerPracticeMode;
+	}
+
+	public TimeSpan GetCurrentDisplayTime()
+	{
+		return !SpeedrunTimerPracticeMode ? CurrentRecord.Time : CurrentRecord.TimePractice;
 	}
 
 	public void SetMusicVolume(int value)

--- a/Source/Scenes/World.cs
+++ b/Source/Scenes/World.cs
@@ -45,6 +45,19 @@ public class World : Scene
 	private int strawbCounterWas;
 
 	private bool IsInEndingArea => Get<Player>() is {} player && Overlaps<EndingArea>(player.Position);
+	
+	private bool IsPracticeTimerPauseState => Get<Player>() is { } player && player.InPausePracticeTimerState;
+
+	private bool IsPracticeTimerRunState
+	{
+		get
+		{
+			if (Game.Instance.IsMidTransition) return false;
+			if (Get<Player>() is not Player player) return true;
+			return player.IsAbleToPause;
+		}
+	}
+	
 	private bool IsPauseEnabled
 	{
 		get
@@ -83,6 +96,8 @@ public class World : Scene
 			optionsMenu.Add(new Menu.Toggle("Fullscreen", Save.Instance.ToggleFullscreen, () => Save.Instance.Fullscreen));
 			optionsMenu.Add(new Menu.Toggle("Z-Guide", Save.Instance.ToggleZGuide, () => Save.Instance.ZGuide));
 			optionsMenu.Add(new Menu.Toggle("Timer", Save.Instance.ToggleTimer, () => Save.Instance.SpeedrunTimer));
+			optionsMenu.Add(new Menu.Toggle("Timer > Practice Mode", Save.Instance.TogglePracticeTimer, () => Save.Instance.SpeedrunTimerPracticeMode));
+
 			optionsMenu.Add(new Menu.Spacer());
 			optionsMenu.Add(new Menu.Slider("BGM", 0, 10, () => Save.Instance.MusicVolume, Save.Instance.SetMusicVolume));
 			optionsMenu.Add(new Menu.Slider("SFX", 0, 10, () => Save.Instance.SfxVolume, Save.Instance.SetSfxVolume));
@@ -276,7 +291,7 @@ public class World : Scene
 		// update audio
 		Audio.SetListener(Camera);
 
-		// increment playtime (if not in the ending area)
+		// increment total playtime (if not in the ending area)
 		if (!IsInEndingArea)
 		{
 			Save.CurrentRecord.Time += TimeSpan.FromSeconds(Time.Delta);
@@ -285,6 +300,12 @@ public class World : Scene
 		else
 		{
 			Game.Instance.Music.Set("at_baddy", 1);
+		}
+
+		// increment practice timer
+		if (IsPracticeTimerRunState)
+		{
+			Save.CurrentRecord.TimePractice += TimeSpan.FromSeconds(Time.Delta);
 		}
 
 		// handle strawb counter
@@ -784,7 +805,24 @@ public class World : Scene
 				var at = bounds.TopLeft + new Vec2(4, 8);
 				if (IsInEndingArea || Save.Instance.SpeedrunTimer)
 				{
-					UI.Timer(batch, Save.CurrentRecord.Time, at, 0.0f, IsInEndingArea ? Color.CornflowerBlue : Color.White);
+					Color timerDisplayColor;
+					if (IsInEndingArea)
+					{
+						timerDisplayColor = Color.CornflowerBlue;
+					}
+					else if (Save.Instance.SpeedrunTimerPracticeMode && IsPracticeTimerPauseState) 
+					{
+						timerDisplayColor = Color.Yellow;
+					}
+					else if (Save.Instance.SpeedrunTimerPracticeMode && !IsPauseEnabled)
+					{
+						timerDisplayColor = Color.Gray;
+					}
+					else
+					{
+						timerDisplayColor = Color.White;
+					}
+					UI.Timer(batch, Save.Instance.GetCurrentDisplayTime(), at, 0.0f, timerDisplayColor);
 					at.Y += UI.IconSize + 4;
 				}
 


### PR DESCRIPTION
re: issue #1

Adds option to enable alternative "practice" timer.

When practice mode for the timer is enabled:
	- Increment the timer while the player has control
	- Reset the timer on respawn and after entering a cassette room
	- Pause the timer when collecting a strawberry and when entering a cassette room

Tested with Linux build