### PR TITLE
Add alternative "practice" timer

### DIFF
--- a/Source/Actors/Player.cs
+++ b/Source/Actors/Player.cs
@@ -170,6 +170,10 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 
 	private bool InBubble
 		=> stateMachine.State == States.Bubble;
+	
+	public bool InPausePracticeTimerState 
+		=> stateMachine.State == States.StrawbGet
+		|| stateMachine.State == States.Cassette;
 
 	public bool IsStrawberryCounterVisible
 		=> stateMachine.State == States.StrawbGet;
@@ -258,6 +262,8 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 		GetCameraTarget(out var orig, out var target, out _);
 		World.Camera.LookAt = target;
 		World.Camera.Position = orig;
+		
+		Save.CurrentRecord.ResetPracticeTimer();
 	}
 
 	public override void Update()

--- a/Source/Actors/Player.cs
+++ b/Source/Actors/Player.cs
@@ -171,10 +171,6 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 	private bool InBubble
 		=> stateMachine.State == States.Bubble;
 	
-	public bool InPausePracticeTimerState 
-		=> stateMachine.State == States.StrawbGet
-		|| stateMachine.State == States.Cassette;
-
 	public bool IsStrawberryCounterVisible
 		=> stateMachine.State == States.StrawbGet;
 
@@ -191,6 +187,10 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 		&& stateMachine.State != States.StrawbGet
 		&& stateMachine.State != States.Cassette
 		&& stateMachine.State != States.Dead;
+    
+    public bool IsSpeedrunPracticeTimePaused 
+        => stateMachine.State == States.StrawbGet 
+        || stateMachine.State == States.Cassette;
 
 	public Player()
 	{
@@ -263,7 +263,7 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 		World.Camera.LookAt = target;
 		World.Camera.Position = orig;
 		
-		Save.CurrentRecord.ResetPracticeTimer();
+		Save.CurrentRecord.ResetSpeedrunPracticeTime();
 	}
 
 	public override void Update()

--- a/Source/Save.cs
+++ b/Source/Save.cs
@@ -20,6 +20,7 @@ public class Save
 		public Dictionary<string, int> Flags { get; set; } = []; 
 		public int Deaths { get; set; } = 0;
 		public TimeSpan Time { get; set; } = new();
+		public TimeSpan TimePractice { get; set; } = new();
 
 		public int GetFlag(string name, int defaultValue = 0) 
 			=> Flags.TryGetValue(name, out int value) ? value : defaultValue;
@@ -29,6 +30,9 @@ public class Save
 
 		public int IncFlag(string name) 
 			=> Flags[name] = GetFlag(name) + 1;
+
+		public void ResetPracticeTimer()
+			=> TimePractice = new TimeSpan();
 	}
 
 	public static Save Instance = new();
@@ -57,6 +61,15 @@ public class Save
 	/// If the Speedrun Timer should be visible while playing
 	/// </summary>
 	public bool SpeedrunTimer { get; set; } = false;
+
+	/// <summary>
+	/// If the Speeedrun Timer should display in "practice" mode rather than show the total playtime
+	/// When practice mode is enabled:
+	///  - Increment the timer while the player has control
+	///  - Reset the timer on respawn and after entering a cassette room
+	///  - Pause the timer when collecting a strawberry and when entering a cassette room
+	/// </summary>
+	public bool SpeedrunTimerPracticeMode { get; set; } = false;
 
 	/// <summary>
 	/// 0-10 Music volume level
@@ -126,6 +139,16 @@ public class Save
 	public void ToggleTimer()
 	{
 		SpeedrunTimer = !SpeedrunTimer;
+	}
+	
+	public void TogglePracticeTimer()
+	{
+		SpeedrunTimerPracticeMode = !SpeedrunTimerPracticeMode;
+	}
+
+	public TimeSpan GetCurrentDisplayTime()
+	{
+		return !SpeedrunTimerPracticeMode ? CurrentRecord.Time : CurrentRecord.TimePractice;
 	}
 
 	public void SetMusicVolume(int value)

--- a/Source/Save.cs
+++ b/Source/Save.cs
@@ -20,7 +20,7 @@ public class Save
 		public Dictionary<string, int> Flags { get; set; } = []; 
 		public int Deaths { get; set; } = 0;
 		public TimeSpan Time { get; set; } = new();
-		public TimeSpan TimePractice { get; set; } = new();
+		public TimeSpan SpeedrunPracticeTime { get; set; } = new();
 
 		public int GetFlag(string name, int defaultValue = 0) 
 			=> Flags.TryGetValue(name, out int value) ? value : defaultValue;
@@ -31,8 +31,8 @@ public class Save
 		public int IncFlag(string name) 
 			=> Flags[name] = GetFlag(name) + 1;
 
-		public void ResetPracticeTimer()
-			=> TimePractice = new TimeSpan();
+		public void ResetSpeedrunPracticeTime()
+			=> SpeedrunPracticeTime = new TimeSpan();
 	}
 
 	public static Save Instance = new();
@@ -69,7 +69,7 @@ public class Save
 	///  - Reset the timer on respawn and after entering a cassette room
 	///  - Pause the timer when collecting a strawberry and when entering a cassette room
 	/// </summary>
-	public bool SpeedrunTimerPracticeMode { get; set; } = false;
+	public bool SpeedrunPracticeTimer { get; set; } = false;
 
 	/// <summary>
 	/// 0-10 Music volume level
@@ -141,14 +141,16 @@ public class Save
 		SpeedrunTimer = !SpeedrunTimer;
 	}
 	
-	public void TogglePracticeTimer()
+	public void ToggleSpeedrunPracticeTime()
 	{
-		SpeedrunTimerPracticeMode = !SpeedrunTimerPracticeMode;
+		SpeedrunPracticeTimer = !SpeedrunPracticeTimer;
 	}
 
 	public TimeSpan GetCurrentDisplayTime()
 	{
-		return !SpeedrunTimerPracticeMode ? CurrentRecord.Time : CurrentRecord.TimePractice;
+		return SpeedrunPracticeTimer 
+            ? CurrentRecord.SpeedrunPracticeTime 
+            : CurrentRecord.Time;
 	}
 
 	public void SetMusicVolume(int value)

--- a/Source/Scenes/World.cs
+++ b/Source/Scenes/World.cs
@@ -46,14 +46,14 @@ public class World : Scene
 
 	private bool IsInEndingArea => Get<Player>() is {} player && Overlaps<EndingArea>(player.Position);
 	
-	private bool IsPracticeTimerPauseState => Get<Player>() is { } player && player.InPausePracticeTimerState;
+	private bool IsSpeedrunPracticeTimerPaused => Get<Player>() is { } player && player.IsSpeedrunPracticeTimePaused;
 
-	private bool IsPracticeTimerRunState
+	private bool IsSpeedrunPracticeTimerRunning
 	{
 		get
 		{
 			if (Game.Instance.IsMidTransition) return false;
-			if (Get<Player>() is not Player player) return true;
+			if (Get<Player>() is not { } player) return true;
 			return player.IsAbleToPause;
 		}
 	}
@@ -96,7 +96,7 @@ public class World : Scene
 			optionsMenu.Add(new Menu.Toggle("Fullscreen", Save.Instance.ToggleFullscreen, () => Save.Instance.Fullscreen));
 			optionsMenu.Add(new Menu.Toggle("Z-Guide", Save.Instance.ToggleZGuide, () => Save.Instance.ZGuide));
 			optionsMenu.Add(new Menu.Toggle("Timer", Save.Instance.ToggleTimer, () => Save.Instance.SpeedrunTimer));
-			optionsMenu.Add(new Menu.Toggle("Timer > Practice Mode", Save.Instance.TogglePracticeTimer, () => Save.Instance.SpeedrunTimerPracticeMode));
+			optionsMenu.Add(new Menu.Toggle("Speedrun Practice Timer", Save.Instance.ToggleSpeedrunPracticeTime, () => Save.Instance.SpeedrunPracticeTimer));
 
 			optionsMenu.Add(new Menu.Spacer());
 			optionsMenu.Add(new Menu.Slider("BGM", 0, 10, () => Save.Instance.MusicVolume, Save.Instance.SetMusicVolume));
@@ -303,9 +303,9 @@ public class World : Scene
 		}
 
 		// increment practice timer
-		if (IsPracticeTimerRunState)
+		if (IsSpeedrunPracticeTimerRunning)
 		{
-			Save.CurrentRecord.TimePractice += TimeSpan.FromSeconds(Time.Delta);
+			Save.CurrentRecord.SpeedrunPracticeTime += TimeSpan.FromSeconds(Time.Delta);
 		}
 
 		// handle strawb counter
@@ -810,11 +810,11 @@ public class World : Scene
 					{
 						timerDisplayColor = Color.CornflowerBlue;
 					}
-					else if (Save.Instance.SpeedrunTimerPracticeMode && IsPracticeTimerPauseState) 
+					else if (Save.Instance.SpeedrunPracticeTimer && IsSpeedrunPracticeTimerPaused) 
 					{
 						timerDisplayColor = Color.Yellow;
 					}
-					else if (Save.Instance.SpeedrunTimerPracticeMode && !IsPracticeTimerRunState)
+					else if (Save.Instance.SpeedrunPracticeTimer && !IsSpeedrunPracticeTimerRunning)
 					{
 						timerDisplayColor = Color.Gray;
 					}


### PR DESCRIPTION
re: issue #1 

Adds option to enable alternative "practice" timer.

When practice mode for the timer is enabled:
	- Increment the timer while the player has control
	- Reset the timer on respawn and after entering a cassette room
	- Pause the timer when collecting a strawberry and when entering a cassette room

Tested using Linux build