### PR TITLE
Fix multiple small issues with the speedrun practice timer

### DIFF
--- a/Source/Actors/Player.cs
+++ b/Source/Actors/Player.cs
@@ -187,10 +187,18 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 		&& stateMachine.State != States.StrawbGet
 		&& stateMachine.State != States.Cassette
 		&& stateMachine.State != States.Dead;
-    
-    public bool IsSpeedrunPracticeTimePaused 
+
+    public bool IsMidPickup
         => stateMachine.State == States.StrawbGet 
         || stateMachine.State == States.Cassette;
+
+    public bool IsActive
+	    => stateMachine.State != States.StrawbGet
+	    && stateMachine.State != States.Cassette
+	    && stateMachine.State != States.StrawbReveal
+	    && stateMachine.State != States.Respawn
+	    && stateMachine.State != States.Dead;
+
 
 	public Player()
 	{
@@ -2140,6 +2148,8 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 		drawModel = drawHair = true;
 		cameraOverride = null;
 		PointShadowAlpha = 1;
+
+		Save.CurrentRecord.ResetSpeedrunPracticeTime();
 	}
 
 	#endregion

--- a/Source/Scenes/World.cs
+++ b/Source/Scenes/World.cs
@@ -46,17 +46,9 @@ public class World : Scene
 
 	private bool IsInEndingArea => Get<Player>() is {} player && Overlaps<EndingArea>(player.Position);
 	
-	private bool IsSpeedrunPracticeTimerPaused => Get<Player>() is { } player && player.IsSpeedrunPracticeTimePaused;
+	private bool IsPlayerMidPickup => Get<Player>() is {} player && player.IsMidPickup;
 
-	private bool IsSpeedrunPracticeTimerRunning
-	{
-		get
-		{
-			if (Game.Instance.IsMidTransition) return false;
-			if (Get<Player>() is not { } player) return true;
-			return player.IsAbleToPause;
-		}
-	}
+	private bool IsPlayerActive => Get<Player>() is {} player && player.IsActive;
 	
 	private bool IsPauseEnabled
 	{
@@ -307,8 +299,8 @@ public class World : Scene
 			Game.Instance.Music.Set("at_baddy", 1);
 		}
 
-		// increment practice timer
-		if (IsSpeedrunPracticeTimerRunning)
+		// increment practice timer (if not in the ending area)
+		if (IsPlayerActive && !IsInEndingArea)
 		{
 			Save.CurrentRecord.SpeedrunPracticeTime += TimeSpan.FromSeconds(Time.Delta);
 		}
@@ -817,11 +809,11 @@ public class World : Scene
 					{
 						timerDisplayColor = Color.CornflowerBlue;
 					}
-					else if (Save.Instance.SpeedrunPracticeTimer && IsSpeedrunPracticeTimerPaused) 
+					else if (Save.Instance.SpeedrunPracticeTimer && IsPlayerMidPickup)
 					{
 						timerDisplayColor = Color.Yellow;
 					}
-					else if (Save.Instance.SpeedrunPracticeTimer && !IsSpeedrunPracticeTimerRunning)
+					else if (Save.Instance.SpeedrunPracticeTimer && !IsPlayerActive)
 					{
 						timerDisplayColor = Color.Gray;
 					}


### PR DESCRIPTION
Pause the timer while on the ending island, reset the timer after exitting a cassette, and update the timer based on player state and not based on game transition step